### PR TITLE
Fix run instructions and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Zbiór nadaje się do zadań z zakresu EDA, regresji, klasyfikacji, a także do 
 1. Sklonuj repozytorium:
 
 `git clone https://github.com/DawidKa00/WD-Projekt-Zaliczeniowy` \
-`cd student-dashboard`
+`cd WD-Projekt-Zaliczeniowy`
 
 2. Zainstaluj zależności:
 
@@ -49,11 +49,11 @@ Zbiór nadaje się do zadań z zakresu EDA, regresji, klasyfikacji, a także do 
 
 3. Jeśli nie masz jeszcze danych w folderze data/, dodaj swój plik kaggle.json (z zakładki "My Account" na kaggle.com):
    
-* Umieść `kaggle.json` w folderze głównym projektu (np. student-dashboard/)
+* Umieść `kaggle.json` w folderze głównym projektu (np. WD-Projekt-Zaliczeniowy/)
 * Plik zostanie automatycznie użyty do pobrania danych podczas pierwszego uruchomienia
 
 4. Uruchom aplikację:
 
-    `python app.py`
+    `python main.py`
 
 Dashboard będzie dostępny pod adresem http://127.0.0.1:8050/.

--- a/data_loader.py
+++ b/data_loader.py
@@ -13,7 +13,7 @@ def download_data_if_needed() -> None:
 
         os.makedirs(DATA_DIR, exist_ok=True)
         if not os.path.exists('kaggle.json'):
-            print("❌ Nie znaleziono pliku kaggle.json w katalogu głównego projekty – potrzebne do pobierania danych z Kaggle.")
+            print("❌ Nie znaleziono pliku kaggle.json w katalogu głównego projektu – potrzebne do pobierania danych z Kaggle.")
             return
         os.environ['KAGGLE_CONFIG_DIR'] = os.getcwd()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+plotly
+dash
+kaggle


### PR DESCRIPTION
## Summary
- add missing `requirements.txt`
- update README instructions for correct repo folder and script name
- fix a typo in `data_loader`

## Testing
- `python -m py_compile data_loader.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68493a2bd9f08332abf2730e891954fd